### PR TITLE
remove deprecated option

### DIFF
--- a/Ansible/ansible.cfg
+++ b/Ansible/ansible.cfg
@@ -40,7 +40,7 @@ roles_path    = ./roles
 host_key_checking = False
 
 # change this for alternative sudo implementations
-sudo_exe = sudo
+#sudo_exe = sudo
 
 # what flags to pass to sudo
 #sudo_flags = -H
@@ -212,14 +212,14 @@ fact_caching = memory
 # (default is sftp)
 #scp_if_ssh = True
 
-[accelerate]
-accelerate_port = 5099
-accelerate_timeout = 30
-accelerate_connect_timeout = 5.0
+#[accelerate]
+#accelerate_port = 5099
+#accelerate_timeout = 30
+#accelerate_connect_timeout = 5.0
 
 # The daemon timeout is measured in minutes. This time is measured
 # from the last activity to the accelerate daemon.
-accelerate_daemon_timeout = 30 
+#accelerate_daemon_timeout = 30 
 
 # If set to yes, accelerate_multi_key will allow multiple
 # private keys to be uploaded to it, though each user must


### PR DESCRIPTION
<!--
SHIFT wareに貢献いただき、ありがとうございます。プルリクエストを作成する前に[SHIFT ware貢献ガイド](https://github.com/SHIFT-ware/shift_ware/blob/master/CONTRIBUTING.md)をご一読ください。
-->

### Summary
* Ansible 2.4への対応に伴い、Deprecatedとなったansible.cfgのオプションをコメントアウトして無効化

### PR Type
* 機能変更